### PR TITLE
Fix typo of “latitude”

### DIFF
--- a/KeyedCodableTests/FlatTests.swift
+++ b/KeyedCodableTests/FlatTests.swift
@@ -14,12 +14,12 @@ private let jsonString = """
         "greeting": "hallo"
     },
     "longitude": 3.2,
-    "lattitude": 3.4
+    "latitude": 3.4
 }
 """
 
 struct Location: Codable {
-    let lattitude: Double
+    let latitude: Double
     let longitude: Double?
 }
 
@@ -50,7 +50,7 @@ class FlatTests: XCTestCase {
 
         KeyedCodableTestHelper.checkEncode(data: jsonData, checkString: false) { (test: InnerWithFlatExample) in
             XCTAssert(test.greeting == "hallo")
-            XCTAssert(test.location?.lattitude == 3.4)
+            XCTAssert(test.location?.latitude == 3.4)
             XCTAssert(test.location?.longitude == 3.2)
         }
     }

--- a/KeyedCodableTests/KeyOptionsTests.swift
+++ b/KeyedCodableTests/KeyOptionsTests.swift
@@ -22,7 +22,7 @@ private let jsonString = """
         }
     },
     "longitude": 3.2,
-    "lattitude": 3.4,
+    "latitude": 3.4,
     "array": [
     {
     "element": 1
@@ -102,7 +102,7 @@ class KeyOptionsTests: XCTestCase {
             XCTAssert(test.greeting == "Hallo world")
             XCTAssert(test.description == "Its nice here")
 
-            XCTAssert(test.location.lattitude == 3.4)
+            XCTAssert(test.location.latitude == 3.4)
             XCTAssert(test.location.longitude == 3.2)
 
             XCTAssert(test.array.count == 3)

--- a/README.md
+++ b/README.md
@@ -89,14 +89,14 @@ Sometimes you may get the json with all properties in one big class. Flat featur
         "greeting": "hallo"
     },
     "longitude": 3.2,
-    "lattitude": 3.4
+    "latitude": 3.4
 }
 ```
 
 ## Keyedable
 ```swift
 struct Location: Codable {
-    let lattitude: Double
+    let latitude: Double
     let longitude: Double
 }
 
@@ -169,7 +169,7 @@ It may happen that keys in the json will conflict with delimiters used by ```Key
         }
     },
     "longitude": 3.2,
-    "lattitude": 3.4,
+    "latitude": 3.4,
     "array": [
     {
     "element": 1


### PR DESCRIPTION
“lattitude” → “latitude”